### PR TITLE
Rename Docker image to timex-datalink-assembler

### DIFF
--- a/asm6805
+++ b/asm6805
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-IMAGE_NAME=timex-datalink-wristapp-assembler
+IMAGE_NAME=timex-datalink-assembler
 IMAGE_VERSION=0.3.0
 
 IMAGE_VERSIONED_TAG="$IMAGE_NAME:v$IMAGE_VERSION"


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-assembler/issues/7!

Renames the Docker image to "timex-datalink-assembler" to be inclusive to how the assembler can also assemble sound schemes.