### PR TITLE
Check if input assembly file exists in asm6805

### DIFF
--- a/asm6805
+++ b/asm6805
@@ -28,7 +28,7 @@ if [ -z "$1" ]; then
 fi
 
 if [ ! -e "$1" ]; then
-  printf '%s %s\n' "$1" "does not exist!"
+  printf '%s %s\n' "$1" "does not exist!" 1>&2
   exit 1
 fi
 

--- a/asm6805
+++ b/asm6805
@@ -27,6 +27,11 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+if [ ! -e "$1" ]; then
+  printf '%s %s\n' "$1" "does not exist!"
+  exit 1
+fi
+
 # If an argument for the output file was passed, use it.  Otherwise, use out.zap.
 if [ -n "$2" ]; then
   output_file=$2


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-assembler/issues/9!

This PR checks if the assembly file exists, and if not, write an error and halt the script.