### PR TITLE
Mention that the assembler is from 1997 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker image for Toebes' Timex Datalink assembler
 
 This repo wraps Toebes' excellent Timex Datalink assembler for the Datalink 150 and 150s in a Docker image with Wine!
-Paired with a helper script called `asm6805`, this Win32 program from 1998 is now presented as a platform-agnostic CLI
+Paired with a helper script called `asm6805`, this Win32 program from 1997 is now presented as a platform-agnostic CLI
 experience:
 
 ```shell


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-assembler/issues/11!

This PR mentions that the assembler is from 1997 in README.md.